### PR TITLE
Fix img related path error

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -3,7 +3,7 @@
     {{ if isset .Params "cover" }}
     <img src="{{ .Params.cover }}" alt="{{ .Title }}" />
     {{ else }}
-    <img src="/img/default{{ index (shuffle (seq 1 4)) 0 }}.jpg" alt="{{ .Title }}" />
+    <img src="{{ "/img/" | relURL }}default{{ index (shuffle (seq 1 4)) 0 }}.jpg" alt="{{ .Title }}" />
     {{ end }}
   </a>
 


### PR DESCRIPTION
Log:
	* Using related path to avoid GET defaultX.jpg error
	  when using non-root url.

Changes to be committed:
	modified:   layouts/_default/summary.html